### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: Build
-
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/jhuebert/iotfsdb/security/code-scanning/1](https://github.com/jhuebert/iotfsdb/security/code-scanning/1)

To fix the issue, we should add an explicit `permissions` block to the workflow YAML file. Since the workflow checks out source code and builds it, it primarily requires read access to repository contents. It does not appear to need write permissions for any GitHub resources like issues or pull requests. Therefore, the minimal required permissions should be set at the root level to apply to all jobs within the workflow. Specifically, `contents: read` is sufficient for this workflow.

Changes will be made to the `.github/workflows/build.yml` file. A top-level `permissions` key will be added after the workflow name to define the least privileges required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
